### PR TITLE
Extract nodes in a way that's compatible with key prefixes with slashes

### DIFF
--- a/src/rabbit_peer_discovery_etcd.erl
+++ b/src/rabbit_peer_discovery_etcd.erl
@@ -30,7 +30,8 @@
 -export([lock_ttl_update_callback/1]).
 
 %% for tests
--export([extract_nodes/1, base_path/1, node_path/1]).
+-export([extract_nodes/1, base_path/1, node_path/1, nodes_path/1,
+         get_node_from_key/2]).
 
 
 %%

--- a/src/rabbit_peer_discovery_etcd.erl
+++ b/src/rabbit_peer_discovery_etcd.erl
@@ -224,10 +224,9 @@ get_node_from_key(V, _Map) ->
   %% so that's what we extract.
   %%
   %% See rabbitmq/rabbitmq-peer-discovery-etcd#14 for details.
-  case re:run(V, <<"/nodes/([^/]+)$">>, [{capture, first, binary}]) of
+  case re:run(V, <<"/nodes/([^/]+)$">>, [{capture, all_but_first, binary}]) of
       nomatch          -> {error, none};
-      {match, [Match]} ->
-          Name = binary:replace(Match, <<"/nodes/">>, <<"">>),
+      {match, [Name]} ->
           ?UTIL_MODULE:node_name(Name)
   end.
 

--- a/src/rabbit_peer_discovery_etcd.erl
+++ b/src/rabbit_peer_discovery_etcd.erl
@@ -190,7 +190,11 @@ node_path(Map) ->
 extract_nodes([], Nodes) -> Nodes;
 extract_nodes([H|T], Nodes) ->
   M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
-  extract_nodes(T, lists:append(Nodes, [get_node_from_key(maps:get(<<"key">>, H), M)])).
+  ToAppend = case get_node_from_key(maps:get(<<"key">>, H), M) of
+                 {error, none} -> [];
+                 Name          -> [Name]
+             end,
+  extract_nodes(T, lists:append(Nodes, ToAppend)).
 
 %% @doc Return the list of erlang nodes
 %% @end

--- a/test/rabbitmq_peer_discovery_etcd_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_etcd_SUITE.erl
@@ -39,7 +39,8 @@ groups() ->
                  get_node_from_key_case2_test,
                  get_node_from_key_case3_test,
                  list_nodes_without_existing_directory_test,
-                 issue14_extract_nodes_test
+                 issue14_extract_nodes_case1_test,
+                 issue14_extract_nodes_case2_test
                 ]}
     ].
 
@@ -150,7 +151,7 @@ list_nodes_without_existing_directory_test(_Config) ->
     rabbit_peer_discovery_etcd:list_nodes(),
     ?assert(meck:validate(rabbit_peer_discovery_httpc)).
 
-issue14_extract_nodes_test(_Config) ->
+issue14_extract_nodes_case1_test(_Config) ->
     Values = #{<<"action">> => <<"get">>,
                <<"node">> =>
                    #{<<"createdIndex">> => 1031,<<"dir">> => true,
@@ -165,3 +166,35 @@ issue14_extract_nodes_test(_Config) ->
                             <<"value">> => <<"enabled">>}]}},
     Expectation = ['rabbit@devops35-2'],
     ?assertEqual(Expectation, rabbit_peer_discovery_etcd:extract_nodes(Values)).
+
+issue14_extract_nodes_case2_test(_Config) ->
+    Values = #{<<"action">> => <<"get">>,
+               <<"node">> =>
+                   #{<<"createdIndex">> => 1031,<<"dir">> => true,
+                     <<"key">> => <<"/nct/co/12.0.4/config/mq/co/nodes">>,
+                     <<"modifiedIndex">> => 1031,
+                     <<"nodes">> =>
+                         [
+                          #{<<"createdIndex">> => 1418809,
+                            <<"expiration">> => <<"2018-08-20T11:53:58.944379602Z">>,
+                            <<"key">> =>
+                                <<"/nct/co/12.0.4/config/mq/co/nodes/rabbit@devops35-1">>,
+                            <<"modifiedIndex">> => 1418809,<<"ttl">> => 26,
+                            <<"value">> => <<"enabled">>},
+
+                          #{<<"createdIndex">> => 1418809,
+                            <<"expiration">> => <<"2018-08-20T11:53:58.944379602Z">>,
+                            <<"key">> =>
+                                <<"/nct/co/12.0.4/config/mq/co/nodes/rabbit@devops35-2">>,
+                            <<"modifiedIndex">> => 1418809,<<"ttl">> => 26,
+                            <<"value">> => <<"enabled">>},
+
+                         #{<<"createdIndex">> => 1418809,
+                            <<"expiration">> => <<"2018-08-20T11:53:58.944379602Z">>,
+                            <<"key">> =>
+                                <<"/nct/co/12.0.4/config/mq/co/no/matches/found/here">>,
+                            <<"modifiedIndex">> => 1418809,<<"ttl">> => 26,
+                            <<"value">> => <<"enabled">>}]}},
+    Expectation = ['rabbit@devops35-1', 'rabbit@devops35-2'],
+    ?assertEqual(lists:usort(Expectation),
+                 lists:usort(rabbit_peer_discovery_etcd:extract_nodes(Values))).

--- a/test/rabbitmq_peer_discovery_etcd_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_etcd_SUITE.erl
@@ -21,7 +21,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-
 all() ->
     [
      {group, unit}
@@ -33,8 +32,10 @@ groups() ->
                  extract_nodes_test,
                  base_path_defaults_test,
                  base_path_custom_test,
+                 base_path_custom_test_with_slash,
                  nodes_path_defaults_test,
                  nodes_path_with_custom_prefix_and_cluster_name_test,
+                 nodes_path_with_custom_prefix_and_cluster_name_with_slash_test,
                  get_node_from_key_case1_test,
                  get_node_from_key_case2_test,
                  get_node_from_key_case3_test,
@@ -43,7 +44,6 @@ groups() ->
                  issue14_extract_nodes_case2_test
                 ]}
     ].
-
 
 reset() ->
     meck:unload(),
@@ -66,8 +66,6 @@ init_per_testcase(_TC, Config) ->
 end_per_testcase(_TC, Config) ->
     reset(),
     Config.
-
-
 
 %%
 %% Test cases
@@ -94,18 +92,21 @@ extract_nodes_test(_Config) ->
     Expectation = ['rabbit@172.17.0.7', 'rabbit@172.17.0.5'],
   ?assertEqual(Expectation, rabbit_peer_discovery_etcd:extract_nodes(Values)).
 
-
 base_path_defaults_test(_Config) ->
     ?assertEqual([v2, keys, "rabbitmq", "default"],
                  rabbit_peer_discovery_etcd:base_path(#{})).
 
-
 base_path_custom_test(_Config) ->
-  C = #{etcd_prefix => <<"example/com/1.2.3/config/mq">>,
-        cluster_name => <<"test_cluster">>},
+    C = #{etcd_prefix => <<"example/com/1.2.3/config/mq">>,
+          cluster_name => <<"test_cluster">>},
     ?assertEqual([v2, keys, "example/com/1.2.3/config/mq", "test_cluster"],
                  rabbit_peer_discovery_etcd:base_path(C)).
 
+base_path_custom_test_with_slash(_Config) ->
+    C = #{etcd_prefix => <<"example/com/1.2.3/config/mq">>,
+          cluster_name => <<"test/cluster">>},
+    ?assertEqual([v2, keys, "example/com/1.2.3/config/mq", "test/cluster"],
+                 rabbit_peer_discovery_etcd:base_path(C)).
 
 nodes_path_defaults_test(_Config) ->
     ?assertEqual([v2, keys, "rabbitmq", "default", nodes, rabbit_data_coercion:to_list(node())],
@@ -113,8 +114,14 @@ nodes_path_defaults_test(_Config) ->
 
 nodes_path_with_custom_prefix_and_cluster_name_test(_Config) ->
     C = #{etcd_prefix => <<"project/prefix/mq">>,
-        cluster_name => <<"test_cluster">>},
+          cluster_name => <<"test_cluster">>},
     ?assertEqual([v2, keys, "project/prefix/mq", "test_cluster", nodes],
+                 rabbit_peer_discovery_etcd:nodes_path(C)).
+
+nodes_path_with_custom_prefix_and_cluster_name_with_slash_test(_Config) ->
+    C = #{etcd_prefix => <<"project/prefix/mq">>,
+          cluster_name => <<"test/cluster">>},
+    ?assertEqual([v2, keys, "project/prefix/mq", "test/cluster", nodes],
                  rabbit_peer_discovery_etcd:nodes_path(C)).
 
 get_node_from_key_case1_test(_Config) ->
@@ -123,13 +130,13 @@ get_node_from_key_case1_test(_Config) ->
 
 get_node_from_key_case2_test(_Config) ->
     C = #{etcd_prefix => <<"project/prefix/mq">>,
-        cluster_name => <<"test_cluster">>},
+          cluster_name => <<"test_cluster">>},
     Key = <<"/nct/co/12.0.4/config/mq/co/nodes/rabbit@devops35-2">>,
     ?assertEqual('rabbit@devops35-2', rabbit_peer_discovery_etcd:get_node_from_key(Key, C)).
 
 get_node_from_key_case3_test(_Config) ->
     C = #{etcd_prefix => <<"project/prefix/mq">>,
-        cluster_name => <<"test_cluster">>},
+          cluster_name => <<"test_cluster">>},
     Key = <<"/nct/co/12.0.4/config/mq/co/nodes/etc/nodes/rabbit@devops35-2">>,
     ?assertEqual('rabbit@devops35-2', rabbit_peer_discovery_etcd:get_node_from_key(Key, C)).
 

--- a/test/rabbitmq_peer_discovery_etcd_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_etcd_SUITE.erl
@@ -36,8 +36,10 @@ groups() ->
                  nodes_path_defaults_test,
                  nodes_path_with_custom_prefix_and_cluster_name_test,
                  get_node_from_key_case1_test,
+                 get_node_from_key_case2_test,
+                 get_node_from_key_case3_test,
                  list_nodes_without_existing_directory_test,
-                 issue14_test
+                 issue14_extract_nodes_test
                 ]}
     ].
 
@@ -115,9 +117,19 @@ nodes_path_with_custom_prefix_and_cluster_name_test(_Config) ->
                  rabbit_peer_discovery_etcd:nodes_path(C)).
 
 get_node_from_key_case1_test(_Config) ->
+    Key = <<"/project/rabbitmq/nodes/rabbit@devops35-2">>,
+    ?assertEqual('rabbit@devops35-2', rabbit_peer_discovery_etcd:get_node_from_key(Key, #{})).
+
+get_node_from_key_case2_test(_Config) ->
     C = #{etcd_prefix => <<"project/prefix/mq">>,
         cluster_name => <<"test_cluster">>},
     Key = <<"/nct/co/12.0.4/config/mq/co/nodes/rabbit@devops35-2">>,
+    ?assertEqual('rabbit@devops35-2', rabbit_peer_discovery_etcd:get_node_from_key(Key, C)).
+
+get_node_from_key_case3_test(_Config) ->
+    C = #{etcd_prefix => <<"project/prefix/mq">>,
+        cluster_name => <<"test_cluster">>},
+    Key = <<"/nct/co/12.0.4/config/mq/co/nodes/etc/nodes/rabbit@devops35-2">>,
     ?assertEqual('rabbit@devops35-2', rabbit_peer_discovery_etcd:get_node_from_key(Key, C)).
 
 list_nodes_without_existing_directory_test(_Config) ->


### PR DESCRIPTION
This changes node name extraction to look for the trailing `/nodes/{name}` sequence.

Relying on slash-separated segments is problematic because
some user-provided segments might contain slashes, e.g. it makes
sense for key prefix values.

Closes #14.

[#159956331]