### PR TITLE
Alias cluster_formation.etcd.lock_timeout to cluster_formation.etcd.lock_wait_time

### DIFF
--- a/priv/schema/rabbitmq_peer_discovery_etcd.schema
+++ b/priv/schema/rabbitmq_peer_discovery_etcd.schema
@@ -91,10 +91,21 @@ end}.
     {validators, ["non_negative_integer"]}
 ]}.
 
+{mapping, "cluster_formation.etcd.lock_timeout", "rabbit.cluster_formation.peer_discovery_etcd.lock_wait_time", [
+    {datatype, integer},
+    {validators, ["non_negative_integer"]}
+]}.
+
+%% an alias for lock acquisition timeout to be consistent with the etcd backend
+
 {translation, "rabbit.cluster_formation.peer_discovery_etcd.lock_wait_time",
 fun(Conf) ->
-    case cuttlefish:conf_get("cluster_formation.etcd.lock_wait_time", Conf, undefined) of
-        undefined -> cuttlefish:unset();
-        Value     -> Value
+    case cuttlefish:conf_get("cluster_formation.etcd.lock_timeout", Conf, undefined) of
+        undefined ->
+            case cuttlefish:conf_get("cluster_formation.etcd.lock_wait_time", Conf, undefined) of
+                    undefined -> cuttlefish:unset();
+                    Value     -> Value
+                end;
+        Value -> Value
     end
 end}.

--- a/test/config_schema_SUITE_data/rabbitmq_peer_discovery_etcd.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_peer_discovery_etcd.snippets
@@ -66,6 +66,18 @@
         ], [rabbitmq_peer_discovery_etcd]
     },
     %% lock acquisition timeout
+    {etcd_lock_wait_time, "cluster_formation.etcd.lock_timeout = 400", [
+            {rabbit, [
+                {cluster_formation, [
+                    {peer_discovery_etcd, [
+                        {lock_wait_time, 400}
+                    ]}
+                ]}
+            ]}
+        ], [rabbitmq_peer_discovery_etcd]
+    },
+
+    %% alias for consistency with etcd
     {etcd_lock_wait_time, "cluster_formation.etcd.lock_wait_time = 400", [
             {rabbit, [
                 {cluster_formation, [


### PR DESCRIPTION
For consistency with the name rabbitmq-peer-discovery-consul now uses. That backend
was updated to support both keys as well.

References rabbitmq/rabbitmq-peer-discovery-consul#20.