### PR TITLE
Alias rabbitmq_peer_discovery_etcd as rabbit_peer_discovery_etcd

### DIFF
--- a/src/rabbit_peer_discovery_etcd.erl
+++ b/src/rabbit_peer_discovery_etcd.erl
@@ -105,7 +105,7 @@ post_registration() ->
 
 lock(Node) when is_atom(Node) ->
     case rabbitmq_peer_discovery_etcd_v3_client:lock(Node) of
-        {ok, GeneratedKey} -> GeneratedKey;
+        {ok, GeneratedKey} -> {ok, GeneratedKey};
         {error, _} = Error -> Error
     end.
 

--- a/src/rabbitmq_peer_discovery_etcd.erl
+++ b/src/rabbitmq_peer_discovery_etcd.erl
@@ -1,0 +1,61 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is AWeber Communications.
+%% Copyright (c) 2015-2016 AWeber Communications
+%% Copyright (c) 2016-2020 VMware, Inc. or its affiliates. All rights reserved.
+%%
+
+-module(rabbitmq_peer_discovery_etcd).
+-behaviour(rabbit_peer_discovery_backend).
+
+-export([init/0, list_nodes/0, supports_registration/0, register/0, unregister/0,
+         post_registration/0, lock/1, unlock/1]).
+
+-define(DELEGATE, rabbit_peer_discovery_etcd).
+
+%%
+%% API
+%%
+
+init() ->
+    ?DELEGATE:init().
+
+-spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} |
+                      {error, Reason :: string()}.
+list_nodes() ->
+    ?DELEGATE:list_nodes().
+
+-spec supports_registration() -> boolean().
+supports_registration() ->
+    ?DELEGATE:supports_registration().
+
+
+-spec register() -> ok.
+register() ->
+    ?DELEGATE:register().
+
+-spec unregister() -> ok.
+unregister() ->
+    ?DELEGATE:unregister().
+
+-spec post_registration() -> ok | {error, Reason :: string()}.
+post_registration() ->
+    ?DELEGATE:post_registration().
+
+-spec lock(Node :: atom()) -> not_supported.
+lock(Node) ->
+    ?DELEGATE:lock(Node).
+
+-spec unlock(Data :: term()) -> ok.
+unlock(Data) ->
+    ?DELEGATE:unlock(Data).


### PR DESCRIPTION
So that if someone assumes that the discovery module name is the same
as plugin name, they don't have to troubleshoot `undef' exceptions.

As a discovered drive-by change this corrects a return value of the locking function in the peer discovery interface.

Closes #26