### PR TITLE
Update gun and eetcd deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PROJECT_MOD = rabbitmq_peer_discovery_etcd_app
 DEPS = rabbit_common rabbitmq_peer_discovery_common rabbit eetcd gun
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers ct_helper meck
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_gun = hex 1.3.2
-dep_eetcd = hex 0.3.2
+dep_gun = hex 1.3.3
+dep_eetcd = hex 0.3.3
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
Gun 1.3.3 has been released and we are waiting on a new eetcd release.

Depends on https://github.com/zhongwencool/eetcd/pull/33